### PR TITLE
Add functions to get molecules' connectivity matrices with aromatic bonds

### DIFF
--- a/EMS.py
+++ b/EMS.py
@@ -9,6 +9,7 @@ import string
 
 from EMS.modules.properties.structure.structure_io import structure_from_rdmol
 from EMS.modules.properties.structure.structure_io import rdmol_to_sdf_block
+from EMS.modules.properties.structure.structure_io import aromatic_bond_from_rdmol
 from EMS.modules.properties.file_io import file_to_rdmol
 from EMS.utils.periodic_table import Get_periodic_table
 from EMS.modules.properties.nmr.nmr_io import nmr_read
@@ -97,6 +98,7 @@ class EMS(object):
         self.type = None                   # The atomic numbers of the atoms in the molecule. Shape: (n_atoms,)
         self.xyz = None                    # The 3D coordinates of the molecule. Shape: (n_atoms, 3)
         self.conn = None                   # The bond order matrix of the molecule. Shape: (n_atoms, n_atoms)
+        self.aromatic_conn = None          # The bond order matrix of the molecule, including aromatic bonds. Shape: (n_atoms, n_atoms)
         self.adj = None                    # The adjacency matrix of the molecule. Shape: (n_atoms, n_atoms)
         self.path_topology = None          # Path length between atoms
         self.path_distance = None          # 3D distance between atoms
@@ -153,6 +155,7 @@ class EMS(object):
 
         # Get the molecular structures
         self.type, self.xyz, self.conn = structure_from_rdmol(self.rdmol)
+        self.aromatic_conn = aromatic_bond_from_rdmol(self.rdmol)
         self.adj = Chem.GetAdjacencyMatrix(self.rdmol) 
         self.path_topology, self.path_distance = self.get_graph_distance()
         self.mol_properties["SMILES"] = Chem.MolToSmiles(self.rdmol)

--- a/modules/dataframe_generation/dataframe_parse.py
+++ b/modules/dataframe_generation/dataframe_parse.py
@@ -105,6 +105,8 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6):
     path_len = []  # number of pairs between atoms (shortest path)
     pair_props = []
     bond_existence = []
+    aromatic_bond_order = []
+
     for propname in ems_list[0].pair_properties.keys():
         pair_props.append([])
 
@@ -125,6 +127,7 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6):
                 dist.append(ems.path_distance[t][t2])
                 path_len.append(int(ems.path_topology[t][t2]))
                 bond_existence.append(ems.adj[t][t2])
+                aromatic_bond_order.append(ems.aromatic_conn[t][t2])
                 for p, prop in enumerate(ems.pair_properties.keys()):
                     pair_props[p].append(ems.pair_properties[prop][t][t2])
 
@@ -147,11 +150,14 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6):
         "distance": dist,
         "path_len": path_len,
         "bond_existence": bond_existence,
+        "bond_order": aromatic_bond_order,
     }
     for p, propname in enumerate(ems.pair_properties.keys()):
         pairs[propname] = pair_props[p]
 
     pairs = pd.DataFrame(pairs)
+    pairs.loc[pairs['bond_order'] == 1.5, 'bond_order'] = 4.0
+    pairs['bond_order'] = pairs['bond_order'].astype(int)
 
     pbar.close()
 


### PR DESCRIPTION
- Add a new attribute: **EMS.aromatic_conn**, to achieve molecules' connectivity matrices with aromatic bonds.
- Add a related helper function **aromatic_bond_from_rdmol** in dataframe_pase.py.