### PR TITLE
Ben dev

### DIFF
--- a/EMS.py
+++ b/EMS.py
@@ -167,12 +167,11 @@ class EMS(object):
         # The error may be caused by wrong explicit valences which are greater than permitted
         self.symmetric = self.check_symmetric()
         
+        # Generate self.pair_properties["nmr_types"] according to the path topology of self.rdmol
+        self.get_coupling_types() 
         
         # Get NMR properties
-        if self.nmr:
-            # Generate self.pair_properties["nmr_types"] according to the path topology of self.rdmol
-            self.get_coupling_types()       
-
+        if self.nmr:      
             # Read NMR data and assign to self.atom_properties and self.pair_properties
             nmr_to_rdmol(self)
 

--- a/modules/dataframe_generation/dataframe_parse.py
+++ b/modules/dataframe_generation/dataframe_parse.py
@@ -94,7 +94,7 @@ def make_atoms_df(ems_list, write=False, format="pickle"):
         return atoms
 
 
-def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_type_limit=False):
+def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6):
     # construct dataframe for pairs in molecule
     # only atom pairs with bonds < max_pathlen are included
 
@@ -106,7 +106,6 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
     pair_props = []
     bond_existence = []
     aromatic_bond_order = []
-    nmr_types = []
 
     for propname in ems_list[0].pair_properties.keys():
         pair_props.append([])
@@ -126,20 +125,10 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
                 atom_index_0.append(t)
                 atom_index_1.append(t2)
                 dist.append(ems.path_distance[t][t2])
-                nmr_types.append(ems.pair_properties["nmr_types"][t][t2])
                 path_len.append(int(ems.path_topology[t][t2]))
                 bond_existence.append(ems.adj[t][t2])
                 aromatic_bond_order.append(ems.aromatic_conn[t][t2])
                 for p, prop in enumerate(ems.pair_properties.keys()):
-                    if nmr_type_limit == True and prop == "nmr_types":
-                        nmr_type = ems.pair_properties[prop][t][t2]
-                        nmr_type_path = nmr_type.split("J")[0]
-                        nmr_type_pair = nmr_type.split("J")[1]
-                        if int(nmr_type_path) > 9:
-                            pair_props[p].append("9J" + nmr_type_pair)
-                        else:
-                            pair_props[p].append(nmr_type)
-                    else:
                         pair_props[p].append(ems.pair_properties[prop][t][t2])
 
                 # for p, prop in enumerate(ems.pair_properties.keys()):
@@ -159,7 +148,6 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
         "atom_index_0": atom_index_0,
         "atom_index_1": atom_index_1,
         "distance": dist,
-        "nmr_types":nmr_types,
         "path_len": path_len,
         "bond_existence": bond_existence,
         "bond_order": aromatic_bond_order,

--- a/modules/dataframe_generation/dataframe_parse.py
+++ b/modules/dataframe_generation/dataframe_parse.py
@@ -106,6 +106,7 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
     pair_props = []
     bond_existence = []
     aromatic_bond_order = []
+    nmr_types = []
 
     for propname in ems_list[0].pair_properties.keys():
         pair_props.append([])
@@ -125,6 +126,7 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
                 atom_index_0.append(t)
                 atom_index_1.append(t2)
                 dist.append(ems.path_distance[t][t2])
+                nmr_types.append(ems.pair_properties["nmr_types"][t][t2])
                 path_len.append(int(ems.path_topology[t][t2]))
                 bond_existence.append(ems.adj[t][t2])
                 aromatic_bond_order.append(ems.aromatic_conn[t][t2])
@@ -157,6 +159,7 @@ def make_pairs_df(ems_list, write=False, format="pickle", max_pathlen=6, nmr_typ
         "atom_index_0": atom_index_0,
         "atom_index_1": atom_index_1,
         "distance": dist,
+        "nmr_types":nmr_types,
         "path_len": path_len,
         "bond_existence": bond_existence,
         "bond_order": aromatic_bond_order,

--- a/tests/test_EMS_class/test_smiles.py
+++ b/tests/test_EMS_class/test_smiles.py
@@ -40,7 +40,7 @@ def test_smiles():
 
     assert type(emol.mol_properties['SMILES']) == str
     assert emol.atom_properties == {}
-    assert emol.pair_properties == {} or (len(emol.pair_properties) == 1 and emol.pair_properties.get('nmr_types') is not None)
+    assert len(emol.pair_properties) == 1 and 'nmr_types' in emol.pair_properties
 
 
 def test_smiles_no_id():

--- a/tests/test_EMS_class/test_smiles.py
+++ b/tests/test_EMS_class/test_smiles.py
@@ -83,4 +83,4 @@ def test_smiles_dataframe_generation():
     atoms_df, pairs_df = make_atoms_df(ems_list), make_pairs_df(ems_list)
     assert atoms_df.shape[0] == len(emol.type)
     assert 'nmr_types' in pairs_df.columns
-    assert int(pairs_df.loc[0, 'nmr_types'][0]) <=9
+    assert int(pairs_df.loc[0, 'nmr_types'].split('J')[0]) <= 9

--- a/tests/test_EMS_class/test_smiles.py
+++ b/tests/test_EMS_class/test_smiles.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 from EMS import EMS as ems
+from modules.dataframe_generation.dataframe_parse import make_atoms_df, make_pairs_df
 
 def test_smiles():
     # Test the EMS class with a SMILES string
@@ -39,7 +40,7 @@ def test_smiles():
 
     assert type(emol.mol_properties['SMILES']) == str
     assert emol.atom_properties == {}
-    assert emol.pair_properties == {}
+    assert emol.pair_properties == {} or (len(emol.pair_properties) == 1 and emol.pair_properties.get('nmr_types') is not None)
 
 
 def test_smiles_no_id():
@@ -73,3 +74,13 @@ def test_smiles_no_id():
     assert emol.pass_valence_check == True
     assert emol.symmetric == 'sym'
     assert emol.nmr == False
+
+def test_smiles_no_id():
+    # Test the EMS class from SMILES string to dataframe
+    smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
+    emol = ems.EMS(file=smiles, mol_id='testmol_smiles_df', nmr=False)
+    ems_list = [emol]
+    atoms_df, pairs_df = make_atoms_df(ems_list), make_pairs_df(ems_list)
+    assert atoms_df.shape[0] == len(emol.type)
+    assert 'nmr_types' in pairs_df.columns
+    assert int(pairs_df.loc[0, 'nmr_types'][0]) <=9

--- a/tests/test_EMS_class/test_smiles.py
+++ b/tests/test_EMS_class/test_smiles.py
@@ -75,7 +75,7 @@ def test_smiles_no_id():
     assert emol.symmetric == 'sym'
     assert emol.nmr == False
 
-def test_smiles_no_id():
+def test_smiles_dataframe_generation():
     # Test the EMS class from SMILES string to dataframe
     smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
     emol = ems.EMS(file=smiles, mol_id='testmol_smiles_df', nmr=False)


### PR DESCRIPTION
- get_coupling_types() is now default function so as to include SMILES string inputs
- Removed 9J default and nmr_type_limit function argument
- New SMILES input pytest checks that nmr_types are generated